### PR TITLE
fix timer and deadlock issues

### DIFF
--- a/src/gui/gui.c
+++ b/src/gui/gui.c
@@ -3644,7 +3644,9 @@ void GUI_Screen_FadeIn(uint16 xSrc, uint16 ySrc, uint16 xDst, uint16 yDst, uint1
 		/* XXX -- This delays the system so you can in fact see the animation */
 		if ((y % 4) == 0) {
 			tick = g_timerSleep;
-			while (tick == g_timerSleep) sleepIdle();
+			while (tick == g_timerSleep) {
+				sleepIdle();
+			}
 		}
 	}
 
@@ -3766,7 +3768,9 @@ void GUI_Screen_FadeIn2(int16 x, int16 y, int16 width, int16 height, uint16 scre
 
 		tick = g_timerSleep + delay;
 
-		while (g_timerSleep < tick) sleepIdle();
+		while (g_timerSleep < tick) {
+			sleepIdle();
+		}
 	}
 
 	if (screenDst == 0) {
@@ -3831,7 +3835,7 @@ void GUI_Mouse_Hide()
  */
 void GUI_Mouse_Hide_Safe()
 {
-	while (g_mouseLock != 0) msleep(0);
+	while (g_mouseLock != 0) sleepIdle();
 	g_mouseLock++;
 
 	if (g_var_7097 == 1) {
@@ -3850,7 +3854,7 @@ void GUI_Mouse_Hide_Safe()
  */
 void GUI_Mouse_Show_Safe()
 {
-	while (g_mouseLock != 0) msleep(0);
+	while (g_mouseLock != 0) sleepIdle();
 	g_mouseLock++;
 
 	if (g_var_7097 == 1) {
@@ -3871,7 +3875,7 @@ void GUI_Mouse_Show_InRegion()
 {
 	uint8 counter;
 
-	while (g_mouseLock != 0) msleep(0);
+	while (g_mouseLock != 0) sleepIdle();
 	g_mouseLock++;
 
 	counter = g_regionFlags & 0xFF;
@@ -3911,7 +3915,7 @@ void GUI_Mouse_Hide_InRegion(uint16 left, uint16 top, uint16 right, uint16 botto
 	maxy = bottom + g_mouseSpriteHotspotY;
 	if (maxy > SCREEN_HEIGHT - 1) maxy = SCREEN_HEIGHT - 1;
 
-	while (g_mouseLock != 0) msleep(0);
+	while (g_mouseLock != 0) sleepIdle();
 	g_mouseLock++;
 
 	if (g_regionFlags == 0) {
@@ -4033,7 +4037,7 @@ void GUI_DrawBlockedRectangle(int16 left, int16 top, int16 width, int16 height, 
  */
 void GUI_Mouse_SetPosition(uint16 x, uint16 y)
 {
-	while (g_mouseLock != 0) msleep(0);
+	while (g_mouseLock != 0) sleepIdle();
 	g_mouseLock++;
 
 	if (x < g_mouseRegionLeft)   x = g_mouseRegionLeft;
@@ -4604,7 +4608,9 @@ void GUI_SetPaletteAnimated(uint8 *palette, int16 ticksOfAnimation)
 		if (progress) {
 			GFX_SetPalette(data);
 
-			while (g_timerSleep < timerCurrent) sleepIdle();
+			while (g_timerSleep < timerCurrent) {
+				sleepIdle();
+			}
 		}
 	} while (progress);
 }

--- a/src/gui/widget_click.c
+++ b/src/gui/widget_click.c
@@ -1363,7 +1363,7 @@ static void GUI_Purchase_ShowInvoice()
 	w = GUI_Widget_Get_ByIndex(w, 10);
 
 	if (w != NULL && Mouse_InsideRegion(w->offsetX, w->offsetY, w->offsetX + w->width, w->offsetY + w->height) != 0) {
-		while (Input_Test(0x41) != 0 || Input_Test(0x42) != 0) msleep(0);
+		while (Input_Test(0x41) != 0 || Input_Test(0x42) != 0) sleepIdle();
 		Input_History_Clear();
 	}
 

--- a/src/input/input.c
+++ b/src/input/input.c
@@ -499,8 +499,7 @@ uint16 Input_Wait()
 
 		value = s_historyHead;
 		if (value != s_historyTail) break;
-
-		msleep(0);
+		sleepIdle();
 	}
 
 	value = Input_ReadHistory(value);
@@ -606,8 +605,7 @@ uint16 Input_WaitForValidInput()
 
 			index = s_historyHead;
 			if (index != s_historyTail) break;
-
-			msleep(0);
+			sleepIdle();
 		}
 
 		value = Input_ReadHistory(index);
@@ -653,8 +651,7 @@ uint16 Input_Keyboard_NextKey()
 		if ((value & 0xFF) >= 0x41 && (value & 0xFF) <= 0x44) index += 4;
 
 		s_historyHead = index + 2;
-
-		msleep(0);
+		sleepIdle();
 	}
 
 	if (value != 0) {

--- a/src/input/mouse.c
+++ b/src/input/mouse.c
@@ -136,7 +136,8 @@ uint16 Mouse_InsideRegion(int16 left, int16 top, int16 right, int16 bottom)
 	int16 mx, my;
 	uint16 inside;
 
-	while (g_mouseLock != 0) msleep(0);
+	sleepIdle(); /* work around no timerevent processing in security loop */
+	while (g_mouseLock != 0) sleepIdle();
 	g_mouseLock++;
 
 	mx = g_mouseX;

--- a/src/opendune.c
+++ b/src/opendune.c
@@ -854,7 +854,9 @@ static void GameCredits_Play(char *data, uint16 windowID, uint16 memory, uint16 
 	Input_History_Clear();
 
 	while (true) {
-		while (loc0C > g_timerSleep) sleepIdle();
+		while (loc0C > g_timerSleep) {
+			sleepIdle();
+		}
 
 		loc0C = g_timerSleep + delay;
 

--- a/src/os/sleep.h
+++ b/src/os/sleep.h
@@ -5,22 +5,10 @@
 #ifndef OS_SLEEP_H
 #define OS_SLEEP_H
 
-#if defined(_WIN32)
-	#include <windows.h>
-	#define sleep(x) Sleep(x * 1000)
-	#define msleep(x) Sleep(x)
-#else
-	#if !defined(__USE_BSD)
-		#define __USE_BSD
-		#include <unistd.h>
-		#undef __USE_BSD
-	#else
-		#include <unistd.h>
-	#endif /* __USE_BSD */
+#include <unistd.h>
+#include "../timer.h"
 
-	#define msleep(x) usleep(x * 1000)
-#endif /* _WIN32 */
-
-#define sleepIdle() msleep(1)
+#define msleep(x) usleep(x * 1000)
+#define sleepIdle() Timer_ProcessEvents();
 
 #endif /* OS_SLEEP_H */

--- a/src/sprites.c
+++ b/src/sprites.c
@@ -11,6 +11,7 @@
 #include "os/sleep.h"
 #include "os/strings.h"
 
+#include "timer.h"
 #include "sprites.h"
 
 #include "codec/format80.h"
@@ -337,7 +338,7 @@ void Sprites_SetMouseSprite(uint16 hotSpotX, uint16 hotSpotY, uint8 *sprite)
 
 	if (sprite == NULL || g_var_7097 != 0) return;
 
-	while (g_mouseLock != 0) msleep(0);
+	while (g_mouseLock != 0) sleepIdle();
 
 	g_mouseLock++;
 

--- a/src/timer.h
+++ b/src/timer.h
@@ -16,6 +16,7 @@ extern uint32 g_timerInput;
 extern uint32 g_timerSleep;
 extern uint32 g_timerTimeout;
 
+extern void Timer_ProcessEvents(void);
 extern void Timer_Sleep(uint16 ticks);
 extern bool Timer_SetTimer(TimerType timer, bool set);
 


### PR DESCRIPTION
using signals is just plain wrong because a signal handler
can get invoked after any instruction, e.g. in the middle of a free
call, leaving bad state in the allocator. if anything in the code
run by the timer causes a new allocation that will break horribly.

a thread is no real option either, because all game state is held in
global variables.

the only sane thing to do is to make "sleepIdle" do the timer code
in a synchronous fashion.
