### PR TITLE
remove hanging midi notes when disabling music

### DIFF
--- a/src/gui/widget_click.c
+++ b/src/gui/widget_click.c
@@ -34,6 +34,7 @@
 #include "../tile.h"
 #include "../timer.h"
 #include "../unit.h"
+#include "../audio/midi.h"
 
 
 char g_savegameDesc[5][51];                                 /*!< Array of savegame descriptions for the SaveLoad window. */
@@ -592,7 +593,12 @@ static void GUI_Widget_GameControls_Click(Widget *w)
 			switch ((key & 0x7FFF) - 0x1E) {
 				case 0:
 					g_gameConfig.music ^= 0x1;
-					if (g_gameConfig.music == 0) Driver_Music_Stop();
+					if (g_gameConfig.music == 0) {
+						Driver_Music_Stop();
+						/* remove eventually hanging notes */
+						midi_uninit();
+						midi_init();
+					}
 					break;
 
 				case 1:


### PR DESCRIPTION
this is a workaround, this way at least the hanging note can be
removed by going into game controls menu and turning music
off and on.

this should also "fix" one of the open issues here.
