### PR TITLE
-Fix (#164): structure fails to deploy units when partially surrounded.

### DIFF
--- a/src/structure.c
+++ b/src/structure.c
@@ -1275,14 +1275,8 @@ uint16 Structure_FindFreePosition(Structure *s, bool checkForSpice)
 			}
 		}
 
-		i++;
+		i = (i + 1) & 0xF;
 		loc12--;
-		if (i <= 15 && offset != 0) {
-			i++;
-		} else {
-			loc12 -= 16 - i;
-			i = 0;
-		}
 	}
 
 	return bestPacked;


### PR DESCRIPTION
A miscalculation in Dune II means that sometimes units will not be released from a structure, even when there are empty tiles around the structure.  This is generally not noticable as the structure will attempt to release the unit a few moments later (I think).  However,  this can cause saboteur to not be released, and you must re-click the palace button to try again.

The problem is in Structure_FindFreePosition, due to incrementing the i variable twice per loop.  The code currently reads:

```
i++;
loc12--;
if (i <= 15 && offset != 0) {
    i++;
} else {
    loc12 -= 16 - i;
    i = 0;
}
```

BTW, the use of offset here is incorrect as i has been incremented (see commit e70b9caf).  It should instead be:

```
g_table_structure_layoutTilesAround[si->layout][i]
```

However, that too looks weird.  It skips over perfectly valid tiles, and potentially takes you to i=16, outside of the range of g_table_structure_layoutTilesAround.

Really, unless you are intent on keeping the skip by two behaviour, it only needs to be:

```
i = (i + 1) & 0xF;
loc12--;
```
