### PR TITLE
-Fix (#166): do not select unit's original location after issuing target.

### DIFF
--- a/src/gui/gui.c
+++ b/src/gui/gui.c
@@ -2149,10 +2149,10 @@ void GUI_ChangeSelectionType(uint16 selectionType)
 		g_var_37B8 = true;
 
 		switch (oldSelectionType) {
-			case SELECTIONTYPE_TARGET:
 			case SELECTIONTYPE_PLACE:
 				Map_SetSelection(g_structureActivePosition);
 				/* Fall-through */
+			case SELECTIONTYPE_TARGET:
 			case SELECTIONTYPE_STRUCTURE:
 				g_cursorDefaultSpriteID = 0;
 				GUI_DisplayText(NULL, -1);


### PR DESCRIPTION
Dune II will sometimes lose the selected unit after issuing an order.  While not random, the behaviour is rather confusing (I never understood why it happened while playing the game).  Steps to reproduce:
1. Select a unit and order it to move (not too close).
2. Order it to move a second time, but don't issue the destination just yet.
3. Wait for it to move at least one tile.
4. Issue the destination.  The unit should be deselected.

The behaviour is caused when switching to and from SELECTIONTYPE_TARGET, in gui/gui.c, GUI_ChangeSelectionType.

When switching to target mode, line 2221: g_structureActivePosition = g_selectionPosition;
This saves the selected unit's position at the time the target command was triggered.

When switching from target mode, line 2154: Map_SetSelection(g_structureActivePosition);
This reselects the saved position, causing the unit to be deselected.
Other units can potentially become selected (e.g. enemy on the chase).
