### PR TITLE
-Fix (#117): correct formula for direction of incoming enemy warning

### DIFF
--- a/enhancement.txt
+++ b/enhancement.txt
@@ -53,8 +53,6 @@ Unit
 ----
 - Once a Unit enters a tile on which it starts to wobble, it will never stop
     wobbling, even if it enters a tile where it shouldn't wobble.
-- The warning of an enemy approach tends to be wrong. This due to a math
-    failure in the code.
 - When a Unit enters a Structure, the last tile the Unit was on becomes
     selected rather than the entire Structure.
 - Deviated units always belong to Ordos, no matter who did the deviating.

--- a/src/unit.c
+++ b/src/unit.c
@@ -2703,12 +2703,7 @@ void Unit_HouseUnitCount_Add(Unit *unit, uint8 houseID)
 
 						s = Structure_Find(&find);
 						if (s != NULL) {
-							/* ENHANCEMENT -- Dune2's calculation is wrong, giving unhelpful messages about the direction of the incoming enemy. */
-							if (g_dune2_enhanced) {
-								feedbackID = ((Orientation_Orientation256ToOrientation16(Tile_GetDirection(s->o.position, unit->o.position)) + 1) & 0xF) / 4 + 2;
-							} else {
-								feedbackID = ((Orientation_Orientation256ToOrientation16(Tile_GetDirection(s->o.position, unit->o.position)) + 1) & 7) / 2 + 1;
-							}
+							feedbackID = ((Orientation_Orientation256ToOrientation8(Tile_GetDirection(s->o.position, unit->o.position)) + 1) & 7) / 2 + 2;
 						} else {
 							feedbackID = 1;
 						}


### PR DESCRIPTION
I am unable to reproduce the claim that the original game gives incorrect directions for the warnings about an incoming enemy in the early levels.  Instead, it seems it was caused by two translation errors in OpenDUNE:

In commit b603fd4b,

emu_Sprites_B4CD_17DC (now "Orientation_Orientation256ToOrientation8") was replaced by
Sprites_B4CD_17F7 ("Orientation_Orientation256ToOrientation16").

And in commit c3e1aa8b,

```
emu_Sprites_B4CD_17DC();
...
emu_shrw(&emu_ax, 0x1);
emu_si = emu_ax;
emu_ax = emu_si;
emu_addw(&emu_ax, 0x2);
```

the "+ 2" here refers to the "enemy approaching from the north" feedback ID, and was replaced by "+ 1" (plain "enemy approaching").

I have restored the original code, and removed it from the list of enhancements.
