### PR TITLE
-Change: don't abort on missing dune.cfg

### DIFF
--- a/src/opendune.c
+++ b/src/opendune.c
@@ -1194,10 +1194,7 @@ int main(int argc, char **argv)
 		exit(1);
 	}
 
-	if (!Config_Read("dune.cfg", &g_config)) {
-		Error("Missing dune.cfg file.\n");
-		exit(1);
-	}
+	if (!Config_Read("dune.cfg", &g_config)) g_config.language = LANGUAGE_ENGLISH;
 
 	Input_Init();
 


### PR DESCRIPTION
Only g_config.language is used, so just default to English.
