### PR TITLE
-Fix (032da23c894468921203ce8557cf4dfcf6f9c728): translation errors in Tile_GetTileInDirectionOf

### DIFF
--- a/src/tile.c
+++ b/src/tile.c
@@ -300,12 +300,12 @@ uint16 Tile_GetTileInDirectionOf(uint16 packed_from, uint16 packed_to)
 
 	if (distance <= 10) return 0;
 
-	for (i = 0; i < 4; i++) {
+	while (true) {
 		int16 dir;
 		tile32 position;
 		uint16 packed;
 
-		dir = 29 + (Tools_Random_256() & 0x3F);
+		dir = 31 + (Tools_Random_256() & 0x3F);
 
 		if ((Tools_Random_256() & 1) != 0) dir = -dir;
 


### PR DESCRIPTION
Looking for some independent verification.  Not sure what the overlays are all about.
1. dir should be incremented by 31 (0x1F) instead of 29.
2. i should not incremented, making it loop until a valid tile is found.
