### PR TITLE
Implement midi_send_string for systems without MIDI

### DIFF
--- a/src/audio/midi_none.c
+++ b/src/audio/midi_none.c
@@ -18,6 +18,13 @@ void midi_send(uint32 data)
 	VARIABLE_NOT_USED(data);
 }
 
+uint16 midi_send_string(const uint8 * data, uint16 len)
+{
+	VARIABLE_NOT_USED(data);
+
+	return len;
+}
+
 void midi_reset(void)
 {
 }


### PR DESCRIPTION
This patch implements `midi_send_string(...)` for `midi_none.c` such that OpenDUNE can be compiled for systems without support for MIDI.