### PR TITLE
Managing SDL1.2/SDL2.0 on Win32 compiling by MSVC

### DIFF
--- a/SDL_Win32.txt
+++ b/SDL_Win32.txt
@@ -7,12 +7,25 @@ However, it is possible using SDL libraries to improve the experience
  window size.
 
 
+Settings for Compiling
+----------------------
+You can edit generate.vbs script to preconfigure Visual Studio
+ project files (re)creation. Set at line 33:
+graph_config = "SDL"
+ or
+graph_config = "SDL2"
+Saving and launching vbscript you will obtain new VS project files
+ with correct included to solution files list.
+Then follow the steps below.
+
+
 Compiling SDL 1.2
 -----------------
 After setting up SDL 1.2 libraries, to successfully compile on MSVC,
  going to Project Properties (All Configurations):
 - on C/C++=>Preprocessor, set WITH_SDL into Preprocessor Definitions
-- on Linker=>System, set /SUBSYSTEM:WINDOWS or /SUBSYSTEM:CONSOLE
+- if you did not put "#undef main" directive on opendune.c source, go
+   on Linker=>System and set /SUBSYSTEM:WINDOWS or /SUBSYSTEM:CONSOLE
    (to define entry point on main for SDL)
 - on Linker=>Command Line, set /FORCE:MULTIPLE on Additional Options
    (to avoid 'multiple definitions' problems)
@@ -23,8 +36,9 @@ Compiling SDL 2.0
 After setting up SDL 2.0 libraries, to successfully compile on MSVC,
  going to Project Properties (All Configurations):
 - on C/C++=>Preprocessor, set WITH_SDL2 into Preprocessor Definitions
-- on Linker=>System, set /SUBSYSTEM:WINDOWS or /SUBSYSTEM:CONSOLE
-  (to define entry point on main for SDL)
+- if you did not put "#undef main" directive on opendune.c source, go
+   on Linker=>System and set /SUBSYSTEM:WINDOWS or /SUBSYSTEM:CONSOLE
+   (to define entry point on main for SDL)
 
 
 Additional Features

--- a/SDL_Win32.txt
+++ b/SDL_Win32.txt
@@ -1,0 +1,35 @@
+Using SDL on Windows Systems
+============================
+By default OpenDUNE on Windows uses WinAPI, so it doesn't require any
+ other library to run on Windows.
+However, it is possible using SDL libraries to improve the experience
+ of gameplaying, being able to toggle fullscreen or zooming in/out the
+ window size.
+
+
+Compiling SDL 1.2
+-----------------
+After setting up SDL 1.2 libraries, to successfully compile on MSVC,
+ going to Project Properties (All Configurations):
+- on C/C++=>Preprocessor, set WITH_SDL into Preprocessor Definitions
+- on Linker=>System, set /SUBSYSTEM:WINDOWS or /SUBSYSTEM:CONSOLE
+   (to define entry point on main for SDL)
+- on Linker=>Command Line, set /FORCE:MULTIPLE on Additional Options
+   (to avoid 'multiple definitions' problems)
+
+
+Compiling SDL 2.0
+-----------------
+After setting up SDL 2.0 libraries, to successfully compile on MSVC,
+ going to Project Properties (All Configurations):
+- on C/C++=>Preprocessor, set WITH_SDL2 into Preprocessor Definitions
+- on Linker=>System, set /SUBSYSTEM:WINDOWS or /SUBSYSTEM:CONSOLE
+  (to define entry point on main for SDL)
+
+
+Additional Features
+-------------------
+While playing OpenDUNE, you can press F11 (or Alt+Enter) to toggle
+ fullscreen, or press +/- keys to zoom in/out window size, maintaining
+ original ratio resolution.
+

--- a/projects/generate.vbs
+++ b/projects/generate.vbs
@@ -39,7 +39,7 @@ Sub safety_check(sourcelist_file)
 
 	' Define regexp
 	Set regexp = New RegExp
-	regexp.Pattern = "#|audio/dsp_sdl.c"
+	regexp.Pattern = "#|audio/dsp_sdl.c|os/thread_sdl.c|video/video_sdl"
 	regexp.Global = True
 
 	' We use a dictionary to check duplicates

--- a/projects/generate.vbs
+++ b/projects/generate.vbs
@@ -163,7 +163,11 @@ Function load_main_data(sourcelist_file, ByRef vcxproj, ByRef filters, ByRef fil
 				Case Else
 					If deep = skip Then
 						line = Replace(line, "/" ,"\")
-						source_list.Add line, "included"
+						If source_list.Exists(line) Then
+							source_list.Item(line) = "included"
+						Else
+							source_list.Add line, "included"
+						End If
 					Else
 						line = Replace(line, "/" ,"\")
 						If Not source_list.Exists(line) Then

--- a/source.list
+++ b/source.list
@@ -87,7 +87,15 @@ opendune.c
 os/endian.c
 #if WIN32
 	os/error_win32.c
-	os/thread_win32.c
+	#if SDL
+		os/thread_sdl.c
+	#else
+		#if SDL2
+			os/thread_sdl.c
+		#else
+			os/thread_win32.c
+		#endif
+	#endif
 	os/readdir_win32.c
 #else
 	#if OSX
@@ -148,7 +156,15 @@ timer.c
 tools.c
 unit.c
 #if WIN32
-	video/video_win32.c
+	#if SDL
+		video/video_sdl.c
+	#else
+		#if SDL2
+			video/video_sdl2.c
+		#else
+			video/video_win32.c
+		#endif
+	#endif
 #else
 	#if SDL2
 		video/video_sdl2.c

--- a/src/input/mouse.c
+++ b/src/input/mouse.c
@@ -298,8 +298,19 @@ void Mouse_HandleMovement(uint16 newButtonState, uint16 mouseX, uint16 mouseY)
 {
 	g_mouseLock = 0x1;
 
+#if defined(_WIN32) && defined(WITH_SDL2)
+	if (g_scale_filter == FILTER_NEAREST_NEIGHBOR) {
+		g_mouseX = mouseX / g_screen_magnification;
+		g_mouseY = mouseY / g_screen_magnification;
+	} else {
+		g_mouseX = mouseX;
+		g_mouseY = mouseY;
+	}
+#else
 	g_mouseX = mouseX;
 	g_mouseY = mouseY;
+#endif
+
 	if (g_mouseMode != INPUT_MOUSE_MODE_PLAY && g_mouseMode != INPUT_MOUSE_MODE_NORMAL && (g_inputFlags & INPUT_FLAG_NO_CLICK) == 0) {
 		Input_HandleInput(Mouse_CheckButtons(newButtonState));
 	}

--- a/src/input/mouse.c
+++ b/src/input/mouse.c
@@ -298,7 +298,7 @@ void Mouse_HandleMovement(uint16 newButtonState, uint16 mouseX, uint16 mouseY)
 {
 	g_mouseLock = 0x1;
 
-#if defined(_WIN32) && defined(WITH_SDL2)
+#if defined(WITH_SDL2)
 	if (g_scale_filter == FILTER_NEAREST_NEIGHBOR) {
 		g_mouseX = mouseX / g_screen_magnification;
 		g_mouseY = mouseY / g_screen_magnification;

--- a/src/opendune.c
+++ b/src/opendune.c
@@ -1155,9 +1155,14 @@ static bool OpenDune_Init(int screen_magnification, VideoScaleFilter filter, int
 		return false;
 	}
 
+	g_screen_magnification = screen_magnification;
+	g_scale_filter = filter;
+
 	Timer_Init();
 
-	if (!Video_Init(screen_magnification, filter)) return false;
+#if !(defined(_WIN32) && (defined(WITH_SDL) || defined(WITH_SDL2)))
+	if (!Video_Init()) return false;
+#endif
 
 	Mouse_Init();
 
@@ -1510,5 +1515,7 @@ void PrepareEnd(void)
 	File_Uninit();
 	Timer_Uninit();
 	GFX_Uninit();
+#if !(defined(_WIN32) && (defined(WITH_SDL2)))
 	Video_Uninit();
+#endif
 }

--- a/src/opendune.c
+++ b/src/opendune.c
@@ -21,6 +21,9 @@
 #include <time.h>
 #if defined(WITH_SDL) || defined(WITH_SDL2)
 #include <SDL.h>
+#ifdef _WIN32
+#undef main
+#endif
 #endif /* WITH_SDL(2) */
 #include "types.h"
 #include "os/common.h"

--- a/src/os/thread.h
+++ b/src/os/thread.h
@@ -4,12 +4,22 @@
 #define OS_THREAD_H
 
 #if defined(_WIN32)
+#if defined(WITH_SDL) || defined(WITH_SDL2)
+	#include <SDL.h>
+	#include <SDL_thread.h>
+	typedef SDL_Thread *Thread;
+	typedef SDL_sem *Semaphore;
+	typedef int ThreadStatus;
+
+	#define WINAPI
+#else
 	#include <windows.h>
 	typedef HANDLE Thread;
 	typedef HANDLE Semaphore;
 	typedef DWORD ThreadStatus;
+#endif
 #else
-/* Thead is only used with Windows
+/* Thread is only used with Windows
 	#include <SDL.h>
 	#include <SDL_thread.h>
 	typedef SDL_Thread *Thread;

--- a/src/video/scale2x.c
+++ b/src/video/scale2x.c
@@ -1612,6 +1612,9 @@ void scale2x_8_altivec(scale2x_uint8* dst0, scale2x_uint8* dst1, const scale2x_u
  * e1 = B if (B == D) && !(B == H) && !(D == F)
  * e2 = B if (B == F) && !(B == H) && !(D == F)
  */
+#if defined(_MSC_VER) && _MSC_VER >= 1800
+#pragma optimize("", off)
+#endif
 static inline void scale2x_8_sse2_border(scale2x_uint8* dst, const scale2x_uint8* src0, const scale2x_uint8* src1, const scale2x_uint8* src2, unsigned count)
 {
 	__m128i B, D, E, F, H, e1, e2;
@@ -1693,6 +1696,9 @@ static inline void scale2x_8_sse2_border(scale2x_uint8* dst, const scale2x_uint8
 	*((__m128i *)dst) = _mm_unpackhi_epi8(e1, e2);
 	dst += 16;
 }
+#if defined(_MSC_VER) && _MSC_VER >= 1800
+#pragma optimize("", on)
+#endif
 
 /**
  * Scale by a factor of 2 a row of pixels of 8 bits.

--- a/src/video/scalebit.c
+++ b/src/video/scalebit.c
@@ -50,7 +50,7 @@
 static inline void stage_scale2x(void* dst0, void* dst1, const void* src0, const void* src1, const void* src2, unsigned pixel, unsigned pixel_per_row)
 {
 	switch (pixel) {
-#if defined(__x86_64__) || defined(_M_X64) || defined(__SSE2__) || (defined(_M_IX86_FP) && (_M_IX86_FP == 2) && defined(WITH_SSE2))
+#if defined(__x86_64__) || defined(_M_X64) || defined(__SSE2__) || (defined(_M_IX86_FP) && (_M_IX86_FP == 2))
 		/* use SSE2 code :
 		 *      if generating x86_64 code (all 64bits x86 CPUs support SSE2)
 		 *      if __SSE2__ is defined (-msse2 with GCC)

--- a/src/video/scalebit.c
+++ b/src/video/scalebit.c
@@ -50,7 +50,7 @@
 static inline void stage_scale2x(void* dst0, void* dst1, const void* src0, const void* src1, const void* src2, unsigned pixel, unsigned pixel_per_row)
 {
 	switch (pixel) {
-#if defined(__x86_64__) || defined(_M_X64) || defined(__SSE2__) || (defined(_M_IX86_FP) && (_M_IX86_FP == 2))
+#if defined(__x86_64__) || defined(_M_X64) || defined(__SSE2__) || (defined(_M_IX86_FP) && (_M_IX86_FP == 2) && defined(WITH_SSE2))
 		/* use SSE2 code :
 		 *      if generating x86_64 code (all 64bits x86 CPUs support SSE2)
 		 *      if __SSE2__ is defined (-msse2 with GCC)

--- a/src/video/video.h
+++ b/src/video/video.h
@@ -9,7 +9,11 @@ typedef enum VideoScaleFilter {
 	FILTER_HQX						/**<! see https://code.google.com/p/hqx/ */
 } VideoScaleFilter;
 
-extern bool Video_Init(int screen_magnification, VideoScaleFilter filter);
+extern VideoScaleFilter g_scale_filter;
+/** The the magnification of the screen. 2 means 640x400, 3 means 960x600, etc. */
+extern int g_screen_magnification;
+
+extern bool Video_Init(void);
 extern void Video_Uninit(void);
 extern void Video_Tick(void);
 extern void Video_SetPalette(void *palette, int from, int length);

--- a/src/video/video_atari.c
+++ b/src/video/video_atari.c
@@ -119,10 +119,10 @@ static void Detect_Machine(void)
 /**
  * Initialize the video driver.
  */
-bool Video_Init(int screen_magnification, VideoScaleFilter filter)
+bool Video_Init(void)
 {
-	VARIABLE_NOT_USED(filter);
-	VARIABLE_NOT_USED(screen_magnification);
+	//VARIABLE_NOT_USED(filter);
+	//VARIABLE_NOT_USED(screen_magnification);
 
 	(void)Cconws("Video_Init()\r\n");
 	if(s_machine_type == MCH_UNKNOWN) Detect_Machine();

--- a/src/video/video_sdl.c
+++ b/src/video/video_sdl.c
@@ -38,10 +38,18 @@
 #define DUNE_ICON_DIR "./"
 #endif
 
-static VideoScaleFilter s_scale_filter;
+#if defined(_WIN32) && defined(WITH_SDL)
+static bool s_fullscreen = false;
+static int s_prev_magnification;
+static int s_desktop_width;
+static int s_desktop_height;
+#endif /* _WIN32 */
+static int s_bpp;
+static int s_surfaceFlags;
+VideoScaleFilter g_scale_filter;
 
 /** The the magnification of the screen. 2 means 640x400, 3 means 960x600, etc. */
-static int s_screen_magnification;
+int g_screen_magnification;
 
 /** The palette used for HQX */
 static uint32 rgb_palette[256];
@@ -149,7 +157,7 @@ static const SDLKey sdlkey_map[] = {
  */
 static void Video_Mouse_Callback(void)
 {
-	Mouse_EventHandler(s_mousePosX / s_screen_magnification, s_mousePosY / s_screen_magnification, s_mouseButtonLeft, s_mouseButtonRight);
+	Mouse_EventHandler(s_mousePosX / g_screen_magnification, s_mousePosY / g_screen_magnification, s_mouseButtonLeft, s_mouseButtonRight);
 }
 
 /**
@@ -177,6 +185,9 @@ static void Video_Mouse_Move(uint16 x, uint16 y)
 	if (s_mouseMaxX != 0 && rx > s_mouseMaxX) rx = s_mouseMaxX;
 	if (s_mouseMinY != 0 && ry < s_mouseMinY) ry = s_mouseMinY;
 	if (s_mouseMaxY != 0 && ry > s_mouseMaxY) ry = s_mouseMaxY;
+
+	if (ry > SCREEN_HEIGHT * g_screen_magnification - 1) ry = SCREEN_HEIGHT * g_screen_magnification - 1;
+	if (rx > SCREEN_WIDTH * g_screen_magnification - 1) rx = SCREEN_WIDTH * g_screen_magnification - 1;
 
 	/* If we moved, send the signal back to the window to correct for it */
 	if (x != rx || y != ry) {
@@ -213,7 +224,7 @@ static void Video_Mouse_Button(bool left, bool down)
  */
 void Video_Mouse_SetPosition(uint16 x, uint16 y)
 {
-	SDL_WarpMouse(x * s_screen_magnification, y * s_screen_magnification);
+	SDL_WarpMouse(x * g_screen_magnification, y * g_screen_magnification);
 }
 
 /**
@@ -225,31 +236,29 @@ void Video_Mouse_SetPosition(uint16 x, uint16 y)
  */
 void Video_Mouse_SetRegion(uint16 minX, uint16 maxX, uint16 minY, uint16 maxY)
 {
-	s_mouseMinX = minX * s_screen_magnification;
-	s_mouseMaxX = maxX * s_screen_magnification;
-	s_mouseMinY = minY * s_screen_magnification;
-	s_mouseMaxY = maxY * s_screen_magnification;
+	s_mouseMinX = minX * g_screen_magnification;
+	s_mouseMaxX = maxX * g_screen_magnification;
+	s_mouseMinY = minY * g_screen_magnification;
+	s_mouseMaxY = maxY * g_screen_magnification;
 }
 
 /**
  * Initialize the video driver.
  */
-bool Video_Init(int screen_magnification, VideoScaleFilter filter)
+bool Video_Init(void)
 {
 #ifndef WITHOUT_SDLIMAGE
 	SDL_Surface * icon;
 #endif /* WITHOUT_SDLIMAGE */
 
 	if (s_video_initialized) return true;
-	if (screen_magnification <= 0 || screen_magnification > 4) {
-		Error("Incorrect screen magnification factor : %d\n", screen_magnification);
+	if (g_screen_magnification <= 0 || g_screen_magnification > 4) {
+		Error("Incorrect screen magnification factor : %d\n", g_screen_magnification);
 		return false;
 	}
-	/* no filter if scale factor is 1 */
-	if (screen_magnification == 1) filter = FILTER_NEAREST_NEIGHBOR;
-	s_scale_filter = filter;
-	s_screen_magnification = screen_magnification;
-	if (filter == FILTER_HQX) {
+	if (g_screen_magnification == 1) g_scale_filter = FILTER_NEAREST_NEIGHBOR;
+
+	if (g_scale_filter == FILTER_HQX) {
 		hqxInit();
 	}
 
@@ -257,6 +266,11 @@ bool Video_Init(int screen_magnification, VideoScaleFilter filter)
 		Error("Could not initialize SDL: %s\n", SDL_GetError());
 		return false;
 	}
+#if defined(_WIN32) && defined(WITH_SDL)
+	SDL_VideoInfo* info = SDL_GetVideoInfo();
+	s_desktop_width = info->current_w;
+	s_desktop_height = info->current_h;
+#endif
 
 #ifndef WITHOUT_SDLIMAGE
 	icon = IMG_Load(DUNE_ICON_DIR "opendune.png");
@@ -268,11 +282,14 @@ bool Video_Init(int screen_magnification, VideoScaleFilter filter)
 #endif /* WITHOUT_SDLIMAGE */
 
 	SDL_WM_SetCaption(window_caption, "OpenDUNE");
-	if (filter == FILTER_HQX) {
-		s_gfx_surface = SDL_SetVideoMode(SCREEN_WIDTH * s_screen_magnification, SCREEN_HEIGHT * s_screen_magnification, 32, SDL_HWSURFACE | SDL_HWACCEL);
+	if (g_scale_filter == FILTER_HQX) {
+		s_surfaceFlags = SDL_SWSURFACE | SDL_HWACCEL;
+		s_bpp = 32;
 	} else {
-		s_gfx_surface = SDL_SetVideoMode(SCREEN_WIDTH * s_screen_magnification, SCREEN_HEIGHT * s_screen_magnification, 8, SDL_HWSURFACE | SDL_HWACCEL | SDL_HWPALETTE);
+		s_surfaceFlags = SDL_SWSURFACE | SDL_HWACCEL | SDL_HWPALETTE;
+		s_bpp = 8;
 	}
+	s_gfx_surface = SDL_SetVideoMode(SCREEN_WIDTH * g_screen_magnification, SCREEN_HEIGHT * g_screen_magnification, s_bpp, s_surfaceFlags);
 	if (s_gfx_surface == NULL) {
 		Error("Could not set resolution: %s\n", SDL_GetError());
 		return false;
@@ -281,7 +298,7 @@ bool Video_Init(int screen_magnification, VideoScaleFilter filter)
 	SDL_ShowCursor(SDL_DISABLE);
 	SDL_EnableKeyRepeat(SDL_DEFAULT_REPEAT_DELAY, SDL_DEFAULT_REPEAT_INTERVAL);
 
-	memset(s_gfx_surface->pixels, 0, SCREEN_WIDTH * SCREEN_HEIGHT * s_screen_magnification * s_screen_magnification);
+	memset(s_gfx_surface->pixels, 0, SCREEN_WIDTH * SCREEN_HEIGHT * g_screen_magnification * g_screen_magnification);
 
 	s_video_initialized = true;
 
@@ -294,7 +311,7 @@ bool Video_Init(int screen_magnification, VideoScaleFilter filter)
 void Video_Uninit(void)
 {
 	s_video_initialized = false;
-	if (s_scale_filter == FILTER_HQX) {
+	if (g_scale_filter == FILTER_HQX) {
 		hqxUnInit();
 	}
 	SDL_Quit();
@@ -304,7 +321,7 @@ static void Video_DrawScreen_Scale2x(void)
 {
 	uint8 *data = GFX_Screen_Get_ByIndex(SCREEN_0);
 	data += (s_screenOffset << 2);
-	scale(s_screen_magnification, s_gfx_surface->pixels, s_screen_magnification * SCREEN_WIDTH, data, SCREEN_WIDTH, 1, SCREEN_WIDTH, SCREEN_HEIGHT);
+	scale(g_screen_magnification, s_gfx_surface->pixels, g_screen_magnification * SCREEN_WIDTH, data, SCREEN_WIDTH, 1, SCREEN_WIDTH, SCREEN_HEIGHT);
 }
 
 static void Video_DrawScreen_Hqx(void)
@@ -314,7 +331,7 @@ static void Video_DrawScreen_Hqx(void)
 	p = GFX_Screen_Get_ByIndex(SCREEN_0);
 	p += (s_screenOffset << 2);
 
-	switch(s_screen_magnification) {
+	switch(g_screen_magnification) {
 	case 2:
 		hq2x_8to32(p, s_gfx_surface->pixels,
 		           SCREEN_WIDTH, SCREEN_HEIGHT, rgb_palette);
@@ -340,7 +357,7 @@ static void Video_DrawScreen_Nearest_Neighbor(void)
 	int i, j;
 
 	data += (s_screenOffset << 2);
-	switch(s_screen_magnification) {
+	switch(g_screen_magnification) {
 	case 1:
 		if (s_gfx_surface->pitch == SCREEN_WIDTH) {
 			memcpy(gfx1, data, SCREEN_WIDTH * SCREEN_HEIGHT);
@@ -434,15 +451,15 @@ static void Video_DrawScreen_Nearest_Neighbor(void)
 		/* The non-optimized works-for-every-magnification method */
 		for (y = 0; y < SCREEN_HEIGHT; y++) {
 			for (x = 0; x < SCREEN_WIDTH; x++) {
-				for (i = 0; i < s_screen_magnification; i++) {
-					for (j = 0; j < s_screen_magnification; j++) {
+				for (i = 0; i < g_screen_magnification; i++) {
+					for (j = 0; j < g_screen_magnification; j++) {
 						*(gfx1 + s_gfx_surface->pitch * j) = *data;
 					}
 					gfx1++;
 				}
 				data++;
 			}
-			gfx1 += s_gfx_surface->pitch * (s_screen_magnification - 1);
+			gfx1 += s_gfx_surface->pitch * (g_screen_magnification - 1);
 		}
 	}
 }
@@ -454,7 +471,7 @@ static void Video_DrawScreen_Nearest_Neighbor(void)
 static void Video_DrawScreen(void)
 {
 	SDL_LockSurface(s_gfx_surface);
-	switch(s_scale_filter) {
+	switch (g_scale_filter) {
 	case FILTER_NEAREST_NEIGHBOR:
 		Video_DrawScreen_Nearest_Neighbor();
 		break;
@@ -470,6 +487,116 @@ static void Video_DrawScreen(void)
 	SDL_UnlockSurface(s_gfx_surface);
 }
 
+#if defined(_WIN32) && defined(WITH_SDL)
+/**
+* Check if Window can be resized
+* @param new_magnification The new magnification to check.
+*/
+static bool Video_CanResize(int32 new_magnification)
+{
+	if ((SCREEN_WIDTH  * new_magnification >= s_desktop_width || SCREEN_HEIGHT * new_magnification >= s_desktop_height) ||
+		new_magnification <= 0) return false;
+
+	return true;
+}
+
+/**
+* Resize SDL_SetVideoMode on Win32.
+*/
+static void Video_Resize(void)
+{
+	SDL_Color colors[256];
+	if (g_scale_filter != FILTER_HQX) {
+		for (int i = 0; i < 256; i++) {
+			colors[i].r = s_gfx_surface->format->palette->colors[i].r;
+			colors[i].g = s_gfx_surface->format->palette->colors[i].g;
+			colors[i].b = s_gfx_surface->format->palette->colors[i].b;
+		}
+	}
+
+	s_gfx_surface = SDL_SetVideoMode(SCREEN_WIDTH * g_screen_magnification, SCREEN_HEIGHT * g_screen_magnification, s_bpp, s_surfaceFlags);
+	if (s_gfx_surface == NULL) {
+		Warning("Failed to toggle full screen\n");
+	} else if (g_scale_filter != FILTER_HQX) {
+		//SDL_SetPalette(s_gfx_surface, SDL_LOGPAL | SDL_PHYSPAL, colors, 0, 256);
+		if (!SDL_SetPalette(s_gfx_surface, SDL_LOGPAL | SDL_PHYSPAL, colors, 0, 256)) Warning("SDL_SetPalette() failed while resizing\n");
+	}
+}
+
+/**
+* Toggle the Fullscreen mode on Win32.
+*/
+static void Video_ToggleFullscreen(void)
+{
+	if (!s_fullscreen) {
+		s_prev_magnification = g_screen_magnification;
+		g_screen_magnification = 2;
+		
+		s_surfaceFlags |= SDL_FULLSCREEN;
+		s_fullscreen = true;
+	} else {
+		if (g_scale_filter == FILTER_HQX) {
+			s_surfaceFlags = SDL_SWSURFACE;
+		} else {
+			s_surfaceFlags = SDL_SWSURFACE | SDL_HWPALETTE;
+		}
+		g_screen_magnification = s_prev_magnification;
+		s_fullscreen = false;
+	}
+
+	if (!Video_CanResize(g_screen_magnification)) {
+		Warning("Cannot Toggle Fullscreen\n");
+	} else {
+		Video_Resize();
+	}
+}
+
+/**
+* Resize Window stretching the images.
+* @param scancode The SDL keysym taken on SDL_KEYUP event type.
+*/
+static void Video_Key_Checks(SDL_keysym keysym)
+{
+	switch (keysym.sym) {
+	case SDLK_F11: {
+		Video_ToggleFullscreen();
+	} break;
+
+	case SDLK_EQUALS:
+	case SDLK_PLUS: {
+		if (s_fullscreen) return;
+
+		if (g_scale_filter == FILTER_NEAREST_NEIGHBOR || (g_scale_filter != FILTER_NEAREST_NEIGHBOR && g_screen_magnification < 4)) {
+			if (!Video_CanResize(g_screen_magnification + 1)) {
+				Video_ToggleFullscreen();
+				return;
+			}
+			++g_screen_magnification;
+			Video_Resize();
+		}
+	} break;
+
+	case SDLK_MINUS: {
+
+		if (s_fullscreen) {
+			Video_ToggleFullscreen();
+			//Video_Resize();
+			s_fullscreen = false;
+			return;
+		}
+
+		if (g_scale_filter == FILTER_NEAREST_NEIGHBOR || (g_scale_filter != FILTER_NEAREST_NEIGHBOR && g_screen_magnification > 2)) {
+			
+			if (!Video_CanResize(g_screen_magnification - 1)) return;
+
+			--g_screen_magnification;
+			Video_Resize();
+		}
+	} break;
+	}
+}
+#endif
+
 /**
  * Runs every tick to handle video driver updates.
  */
@@ -478,13 +605,28 @@ void Video_Tick(void)
 	SDL_Event event;
 	static bool s_showFPS = false;
 
+#if defined(_WIN32) && defined(WITH_SDL)
+	if (!s_video_initialized) Video_Init();
+#else
 	if (!s_video_initialized) return;
+#endif
 
 	if (g_fileOperation != 0) return;
 
 	if (s_video_lock) return;
 	s_video_lock = true;
 
+#if defined(_WIN32) && defined(WITH_SDL)
+	if (!g_running && s_fullscreen) {
+		if (g_scale_filter == FILTER_HQX) {
+			s_surfaceFlags = SDL_SWSURFACE;
+		} else {
+			s_surfaceFlags = SDL_SWSURFACE | SDL_HWPALETTE;
+		}
+		g_screen_magnification = s_prev_magnification;
+		Video_Resize();
+	}
+#endif
 	if (s_showFPS) {
 		Video_ShowFPS(GFX_Screen_Get_ByIndex(SCREEN_0));
 	}
@@ -519,6 +661,14 @@ void Video_Tick(void)
 			{
 				uint8 scancode;	/* AT keyboard scancode */
 				SDLKey sym = event.key.keysym.sym;	/* SDLKey symbolic code */
+#if defined(_WIN32)
+				SDL_keysym keysym = event.key.keysym;
+				if (!keyup && keysym.sym == SDLK_RETURN && (keysym.mod & KMOD_ALT)) {
+					Video_ToggleFullscreen();
+					continue;
+				}
+				if (!keyup) Video_Key_Checks(keysym);
+#else
 				if (sym == SDLK_RETURN && (event.key.keysym.mod & KMOD_ALT)) {
 					/* ALT-ENTER was pressed */
 					if (!keyup) continue; /* ignore keydown */
@@ -527,6 +677,7 @@ void Video_Tick(void)
 					}
 					continue;
 				}
+#endif
 				if (sym == SDLK_F8 && !keyup) {
 					s_showFPS = !s_showFPS;
 					continue;
@@ -566,7 +717,8 @@ void Video_Tick(void)
 	}
 
 	/* Do a quick compare to see if the screen changed at all */
-	if (!s_screen_needrepaint && memcmp(GFX_Screen_Get_ByIndex(SCREEN_0), s_gfx_screen8, SCREEN_WIDTH * SCREEN_HEIGHT) == 0) {
+	if (g_scale_filter == FILTER_HQX && !s_screen_needrepaint && 
+		memcmp(GFX_Screen_Get_ByIndex(SCREEN_0), s_gfx_screen8, SCREEN_WIDTH * SCREEN_HEIGHT) == 0) {
 		s_video_lock = false;
 		return;
 	}
@@ -594,7 +746,7 @@ void Video_SetPalette(void *palette, int from, int length)
 
 	s_video_lock = true;
 
-	if (s_scale_filter == FILTER_HQX) {
+	if (g_scale_filter == FILTER_HQX) {
 		uint32 value;
 		for (i = from; i < from + length; i++) {
 			value = (((*p++) & 0x3F) * 0x41000) & 0xff0000;

--- a/src/video/video_sdl2.c
+++ b/src/video/video_sdl2.c
@@ -373,27 +373,6 @@ static void Video_DrawScreen_Nearest_Neighbor(void)
 		pixels += pitch;
 	}
 	SDL_UnlockTexture(s_texture);
-
-	SDL_Rect Src, Dest;
-	Src.w = SCREEN_WIDTH;
-	Src.h = SCREEN_HEIGHT;
-	Src.x = 0;
-	Src.y = 0;
-	Dest.w = SCREEN_WIDTH * g_screen_magnification;
-	Dest.h = SCREEN_HEIGHT * g_screen_magnification;
-	if (!s_fullscreen) {
-		Dest.x = 0;
-		Dest.y = 0;
-	} else {
-		SDL_DisplayMode current;
-		SDL_GetCurrentDisplayMode(0, &current);
-		Dest.x = (current.w - Dest.w) / 2;
-		Dest.y = (current.h - Dest.h) / 2;
-	}
-
-	if (SDL_RenderCopy(s_renderer, s_texture, &Src, &Dest)) {
-		Error("SDL_RenderCopy failed : %s\n", SDL_GetError());
-	}
 }
 
 static void Video_DrawScreen_Scale2x(void)
@@ -447,27 +426,6 @@ static void Video_DrawScreen_Scale2x(void)
 		pixels += pitch;
 	}
 	SDL_UnlockTexture(s_texture);
-
-	SDL_Rect Src, Dest;
-	Src.w = SCREEN_WIDTH * g_screen_magnification;
-	Src.h = SCREEN_HEIGHT * g_screen_magnification;
-	Src.x = 0;
-	Src.y = 0;
-	Dest.w = SCREEN_WIDTH * g_screen_magnification;
-	Dest.h = SCREEN_HEIGHT * g_screen_magnification;
-	if (!s_fullscreen) {
-		Dest.x = 0;
-		Dest.y = 0;
-	} else {
-		SDL_DisplayMode current;
-		SDL_GetCurrentDisplayMode(0, &current);
-		Dest.x = (current.w - Dest.w) / 2;
-		Dest.y = (current.h - Dest.h) / 2;
-	}
-
-	if (SDL_RenderCopy(s_renderer, s_texture, &Src, &Dest)) {
-		Error("SDL_RenderCopy failed : %s\n", SDL_GetError());
-	}
 }
 
 static void Video_DrawScreen_Hqx(void)
@@ -519,6 +477,23 @@ static void Video_DrawScreen_Hqx(void)
 		break;
 	}
 	SDL_UnlockTexture(s_texture);
+}
+
+static void Video_DrawScreen(void)
+{
+	switch(g_scale_filter) {
+	case FILTER_NEAREST_NEIGHBOR:
+		Video_DrawScreen_Nearest_Neighbor();
+		break;
+	case FILTER_SCALE2X:
+		Video_DrawScreen_Scale2x();
+		break;
+	case FILTER_HQX:
+		Video_DrawScreen_Hqx();
+		break;
+	default:
+		Error("Unsupported scale filter\n");
+	}
 
 	SDL_Rect Src, Dest;
 	Src.w = SCREEN_WIDTH * g_screen_magnification;
@@ -539,23 +514,6 @@ static void Video_DrawScreen_Hqx(void)
 
 	if (SDL_RenderCopy(s_renderer, s_texture, &Src, &Dest)) {
 		Error("SDL_RenderCopy failed : %s\n", SDL_GetError());
-	}
-}
-
-static void Video_DrawScreen(void)
-{
-	switch(g_scale_filter) {
-	case FILTER_NEAREST_NEIGHBOR:
-		Video_DrawScreen_Nearest_Neighbor();
-		break;
-	case FILTER_SCALE2X:
-		Video_DrawScreen_Scale2x();
-		break;
-	case FILTER_HQX:
-		Video_DrawScreen_Hqx();
-		break;
-	default:
-		Error("Unsupported scale filter\n");
 	}
 }
 

--- a/src/video/video_win32.c
+++ b/src/video/video_win32.c
@@ -24,10 +24,10 @@
 #define VIDEO_STATS
 #endif
 
-static VideoScaleFilter s_scale_filter;
+VideoScaleFilter g_scale_filter;
 
 /** The the magnification of the screen. 2 means 640x400, 3 means 960x600, etc. */
-static int s_screen_magnification;
+int g_screen_magnification;
 
 /** The palette used for HQX */
 static uint32 rgb_palette[256];
@@ -250,13 +250,14 @@ static LRESULT CALLBACK WindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM l
 			HBITMAP old_bmp;
 
 			if (!GetUpdateRect(hwnd, NULL, FALSE)) return 0;
+
 			if (s_showFPS) {
 				Video_ShowFPS(s_screen);
 			}
-			if (s_scale_filter == FILTER_SCALE2X) {
-				scale(s_screen_magnification, s_screen2, s_screen_magnification * SCREEN_WIDTH, s_screen, SCREEN_WIDTH, 1, SCREEN_WIDTH, SCREEN_HEIGHT);
-			} else if(s_scale_filter == FILTER_HQX) {
-				switch(s_screen_magnification) {
+			if (g_scale_filter == FILTER_SCALE2X) {
+				scale(g_screen_magnification, s_screen2, g_screen_magnification * SCREEN_WIDTH, s_screen, SCREEN_WIDTH, 1, SCREEN_WIDTH, SCREEN_HEIGHT);
+			} else if(g_scale_filter == FILTER_HQX) {
+				switch(g_screen_magnification) {
 				case 2:
 					hq2x_8to32(s_screen, s_screen2, SCREEN_WIDTH, SCREEN_HEIGHT, rgb_palette);
 					break;
@@ -271,14 +272,14 @@ static LRESULT CALLBACK WindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM l
 			dc = BeginPaint(hwnd, &ps);
 			dc2 = CreateCompatibleDC(dc);
 			old_bmp = (HBITMAP)SelectObject(dc2, s_dib);
-			switch (s_scale_filter) {
+			switch (g_scale_filter) {
 			case FILTER_HQX:
 			case FILTER_SCALE2X:
-				BitBlt(dc, 0, 0, SCREEN_WIDTH * s_screen_magnification, SCREEN_HEIGHT * s_screen_magnification, dc2, 0, 0, SRCCOPY);
+				BitBlt(dc, 0, 0, SCREEN_WIDTH * g_screen_magnification, SCREEN_HEIGHT * g_screen_magnification, dc2, 0, 0, SRCCOPY);
 				break;
 			case FILTER_NEAREST_NEIGHBOR:
 			default:
-				/*StretchBlt(dc, 0, 0, SCREEN_WIDTH * s_screen_magnification, SCREEN_HEIGHT * s_screen_magnification, dc2, 0, 0, SCREEN_WIDTH, SCREEN_HEIGHT, SRCCOPY);*/
+				/*StretchBlt(dc, 0, 0, SCREEN_WIDTH * g_screen_magnification, SCREEN_HEIGHT * g_screen_magnification, dc2, 0, 0, SCREEN_WIDTH, SCREEN_HEIGHT, SRCCOPY);*/
 				StretchBlt(dc, 0, 0, s_window_width, s_window_height,
 					       dc2, 0, 0, SCREEN_WIDTH, SCREEN_HEIGHT, SRCCOPY);
 			}
@@ -416,7 +417,7 @@ static LRESULT CALLBACK WindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM l
 	return DefWindowProc(hwnd, uMsg, wParam, lParam);
 }
 
-bool Video_Init(int screen_magnification, VideoScaleFilter filter)
+bool Video_Init(void)
 {
 	WNDCLASS wc;
 	HINSTANCE hInstance;
@@ -424,15 +425,13 @@ bool Video_Init(int screen_magnification, VideoScaleFilter filter)
 	HDC dc;
 
 	if (s_init) return true;
-	if (screen_magnification <= 0 || screen_magnification > 4) {
-		Error("Incorrect screen magnification factor : %d\n", screen_magnification);
+	if (g_screen_magnification <= 0 || g_screen_magnification > 4) {
+		Error("Incorrect screen magnification factor : %d\n", g_screen_magnification);
 		return false;
 	}
-	if (screen_magnification == 1) filter = FILTER_NEAREST_NEIGHBOR;
-	s_screen_magnification = screen_magnification;
-	s_scale_filter = filter;
+	if (g_screen_magnification == 1) g_scale_filter = FILTER_NEAREST_NEIGHBOR;
 
-	if (filter == FILTER_HQX) {
+	if (g_scale_filter == FILTER_HQX) {
 		hqxInit();
 	}
 
@@ -472,15 +471,15 @@ bool Video_Init(int screen_magnification, VideoScaleFilter filter)
 	bi = (BITMAPINFO*)_alloca(sizeof(BITMAPINFOHEADER) + sizeof(RGBQUAD) * 256);
 	memset(bi, 0, sizeof(BITMAPINFOHEADER) + sizeof(RGBQUAD) * 256);
 	bi->bmiHeader.biSize = sizeof(BITMAPINFOHEADER);
-	if (filter == FILTER_NEAREST_NEIGHBOR) {
+	if (g_scale_filter == FILTER_NEAREST_NEIGHBOR) {
 		bi->bmiHeader.biWidth = SCREEN_WIDTH;
 		bi->bmiHeader.biHeight = -SCREEN_HEIGHT;
 	} else {
-		bi->bmiHeader.biWidth = SCREEN_WIDTH * s_screen_magnification;
-		bi->bmiHeader.biHeight = -SCREEN_HEIGHT * s_screen_magnification;
+		bi->bmiHeader.biWidth = SCREEN_WIDTH * g_screen_magnification;
+		bi->bmiHeader.biHeight = -SCREEN_HEIGHT * g_screen_magnification;
 	}
 	bi->bmiHeader.biPlanes = 1;
-	if (filter == FILTER_HQX) {
+	if (g_scale_filter == FILTER_HQX) {
 		bi->bmiHeader.biBitCount = 32;
 	} else {
 		bi->bmiHeader.biBitCount = 8;
@@ -488,7 +487,7 @@ bool Video_Init(int screen_magnification, VideoScaleFilter filter)
 	bi->bmiHeader.biCompression = BI_RGB;
 
 	dc = GetDC(NULL);
-	s_dib = CreateDIBSection(dc, bi, DIB_RGB_COLORS, (filter == FILTER_NEAREST_NEIGHBOR) ? &s_screen : &s_screen2, NULL, 0);
+	s_dib = CreateDIBSection(dc, bi, DIB_RGB_COLORS, (g_scale_filter == FILTER_NEAREST_NEIGHBOR) ? &s_screen : &s_screen2, NULL, 0);
 	if (s_dib == NULL) {
 		Error("CreateDIBSection failed\n");
 		return false;
@@ -512,7 +511,7 @@ bool Video_Init(int screen_magnification, VideoScaleFilter filter)
 #endif /* VIDEO_STATS */
 	ReleaseDC(NULL, dc);
 
-	if (filter != FILTER_NEAREST_NEIGHBOR) {
+	if (g_scale_filter != FILTER_NEAREST_NEIGHBOR) {
 #ifdef _MSC_VER
 		/* we need aligned memory for rescale filter */
 		s_screen = _aligned_malloc(SCREEN_WIDTH * SCREEN_HEIGHT, 16);
@@ -529,7 +528,7 @@ void Video_Uninit(void)
 	if (!s_init) return;
 
 	DeleteObject(s_dib);
-	if (s_scale_filter != FILTER_NEAREST_NEIGHBOR) {
+	if (g_scale_filter != FILTER_NEAREST_NEIGHBOR) {
 #ifdef _MSC_VER
 		_aligned_free(s_screen);
 #else  /* _MSC_VER */
@@ -539,7 +538,7 @@ void Video_Uninit(void)
 	UnregisterClass(s_className, GetModuleHandle(NULL));
 	ShowCursor(TRUE);
 
-	if (s_scale_filter == FILTER_HQX) {
+	if (g_scale_filter == FILTER_HQX) {
 		hqxUnInit();
 	}
 	s_init = false;
@@ -617,17 +616,17 @@ void Video_Tick(void)
 
 		style = WS_CAPTION | WS_MINIMIZEBOX | WS_SYSMENU;
 		/* allow window to be resized with NEAREST NEIGHBOR filter */
-		if(s_scale_filter == FILTER_NEAREST_NEIGHBOR) style |= WS_THICKFRAME;
+		if(g_scale_filter == FILTER_NEAREST_NEIGHBOR) style |= WS_THICKFRAME;
 
 		r.left   = 0;
 		r.top    = 0;
-		r.right  = SCREEN_WIDTH * s_screen_magnification;
-		r.bottom = SCREEN_HEIGHT * s_screen_magnification;
+		r.right  = SCREEN_WIDTH * g_screen_magnification;
+		r.bottom = SCREEN_HEIGHT * g_screen_magnification;
 		AdjustWindowRect(&r, style, false);
 		s_adjustLeft = r.left;
 		s_adjustTop = r.top;
-		s_adjustRight = r.right - SCREEN_WIDTH * s_screen_magnification;
-		s_adjustBottom = r.bottom - SCREEN_HEIGHT * s_screen_magnification;
+		s_adjustRight = r.right - SCREEN_WIDTH * g_screen_magnification;
+		s_adjustBottom = r.bottom - SCREEN_HEIGHT * g_screen_magnification;
 
 		s_hwnd = CreateWindow(s_className, window_caption, style, CW_USEDEFAULT, CW_USEDEFAULT, r.right - r.left, r.bottom - r.top, NULL, NULL, GetModuleHandle(NULL), NULL);
 		if (s_hwnd == NULL) {
@@ -679,7 +678,7 @@ void Video_SetPalette(void *palette, int from, int length)
 	uint8 *p = palette;
 	int i;
 
-	if (s_scale_filter == FILTER_HQX) {
+	if (g_scale_filter == FILTER_HQX) {
 		uint32 value;
 
 		for (i = from; i < from + length; i++) {
@@ -724,15 +723,15 @@ void Video_SetPalette(void *palette, int from, int length)
 
 void Video_Mouse_SetPosition(uint16 x, uint16 y)
 {
-	SetCursorPos(s_x + x * s_screen_magnification, s_y + y * s_screen_magnification);
+	SetCursorPos(s_x + x * g_screen_magnification, s_y + y * g_screen_magnification);
 }
 
 void Video_Mouse_SetRegion(uint16 minX, uint16 maxX, uint16 minY, uint16 maxY)
 {
-	s_mouseMinX = minX * s_screen_magnification;
-	s_mouseMaxX = maxX * s_screen_magnification;
-	s_mouseMinY = minY * s_screen_magnification;
-	s_mouseMaxY = maxY * s_screen_magnification;
+	s_mouseMinX = minX * g_screen_magnification;
+	s_mouseMaxX = maxX * g_screen_magnification;
+	s_mouseMinY = minY * g_screen_magnification;
+	s_mouseMaxY = maxY * g_screen_magnification;
 }
 
 /*


### PR DESCRIPTION
This PR manages full SDL1.2/SDL2.0 support on Windows Systems and MSVC.
PR includes the making screen_magnification and scale_filter as global (extern) variables, to use them out of video driver module.
Press Plus (+) / Minus (-) keys to increase/decrease window size, F11 (or Alt+Enter) to toggle fullscreen. Original ratio resolution will be maintained.
Support to scale2x and hqx scalers are maintaned too.

To correctly compile on MSVC, just read SDL_Win32.txt