### PR TITLE
Fixed build on MinGW with GCC

### DIFF
--- a/config.lib
+++ b/config.lib
@@ -984,6 +984,7 @@ make_cflags_and_ldflags() {
 	# And others like Windows
 	if [ "$os" = "MINGW" ] || [ "$os" = "CYGWIN" ] || [ "$os" = "WINCE" ]; then
 		CFLAGS="$CFLAGS -DWIN"
+		LIBS="$LIBS -lShlwapi"
 	fi
 
 	if [ "$os" = "TOS" ]; then

--- a/src/os/file.h
+++ b/src/os/file.h
@@ -8,6 +8,10 @@
 	#define unlink _unlink
 	#include <ShlObj.h>
 	#include <Shlwapi.h>
+#elif defined(_WIN32)
+	#include <io.h>
+	#include <ShlObj.h>
+	#include <Shlwapi.h>
 #else /* _MSC_VER */
 	#include <unistd.h>
 #endif /* _MSC_VER */

--- a/src/video/video_win32.c
+++ b/src/video/video_win32.c
@@ -399,7 +399,7 @@ static LRESULT CALLBACK WindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM l
 			}
 
 			scan = MapKey(wParam);
-			// Real scancode is also ((lParam >> 16) & 0xff)
+			/* Real scancode is also ((lParam >> 16) & 0xff) */
 
 			if (scan == 0) {
 				Warning("Unhandled key %X (='%c')  (scan = %x)\n", wParam, wParam >= 32 ? wParam : '.', (lParam >> 16) & 0xff);


### PR DESCRIPTION
When using GCC, libs and include files required by file.c are not appended. This is due to:
 - Checking for `_MSC_VER` within `file.h`, which is not declared by GCC
-  Missing `-lShlwapi` link flag

Additionally, a comment in  `src/video/video_win32.c` wasn't compliant with ISO C90 and was causing build failures.
With these sorted out, OpenDUNE builds and runs. However there are many warnings emitted by GCC about string functions like `strcasecmp` and `strdup` being redefined