### PR TITLE
Munt requires -lm

### DIFF
--- a/config.lib
+++ b/config.lib
@@ -1087,7 +1087,7 @@ make_cflags_and_ldflags() {
 	fi
 
 	if [ "$with_munt" != "0" ]; then
-		LIBS="$LIBS -lmt32emu -lstdc++"
+		LIBS="$LIBS -lmt32emu -lm -lstdc++"
 		CFLAGS="$CFLAGS -DMUNT"
 	fi
 


### PR DESCRIPTION
Munt requires -lm link flag (and newer versions of gcc is picky on the link order)