### PR TITLE
SDL full-screen viewport scroll-down fix

### DIFF
--- a/src/input/mouse.c
+++ b/src/input/mouse.c
@@ -78,6 +78,15 @@ void Mouse_EventHandler(uint16 mousePosX, uint16 mousePosY, bool mouseButtonLeft
 {
 	uint8 newButtonState = (mouseButtonLeft ? 0x1 : 0x0) | (mouseButtonRight ? 0x2 : 0x0);
 
+	/* some of the input sources might be a bit sloppy on restricting the X/Y upper limits, so we clamp the values */
+	if (mousePosX >= 320) {
+		mousePosX = 319;
+	}
+
+	if (mousePosY >= 200) {
+		mousePosY = 199;
+	}
+
 	if (g_mouseDisabled == 0) {
 		if (g_mouseMode == INPUT_MOUSE_MODE_NORMAL && (g_inputFlags & INPUT_FLAG_NO_CLICK) == 0) {
 			Input_HandleInput(Mouse_CheckButtons(newButtonState));


### PR DESCRIPTION
When running the game with SDL fullscreen mode, which adds scaling,
we might receive mousePosX and mousePosY values that are one pixel
too high. This causes artifacts when scrolling the map down, since
the mouse cursor is not hidden, since the value is unexpected and
not properly handled. This fix unsures that all mouse input
drivers always clamps at the correct values.