### PR TITLE
Support for Atari ST/STE with 030 accelerators

### DIFF
--- a/README.atari
+++ b/README.atari
@@ -1,4 +1,4 @@
-To get OpenDUNE running on Atari Falcon and TT :
+To get OpenDUNE running on Atari Falcon, TT and accelerated ST/STE:
 
 
 * building
@@ -29,6 +29,9 @@ to enable the MT32 songs.
 
 - 320x200 (RGB) or 320x240 (VGA) 8bpp modes are used on Falcon.
 TT Low (320x480 8bpp) is used on TT.
+ST Low (320x200 4bpp) is used on ST/STE.
+
+- ST/STE requires 68030 accelerator or better
 
 - Keyboard and mouse input is managed with a custom IKBD interrupt
 handler.

--- a/README.txt
+++ b/README.txt
@@ -34,7 +34,7 @@ Currently we officially support the following platforms:
   - FreeBSD
   - Mac OS X (PowerPC or Intel i686 / x86_64, 10.4+)
   - Windows (i686 / x86_64)
-  - Atari TOS (68030+ CPU, TT and Falcon machines supported)
+  - Atari TOS (68030+ CPU, TT, Falcon, accelerated ST/STE machines supported)
 
 
 Requirements

--- a/README.txt
+++ b/README.txt
@@ -34,7 +34,7 @@ Currently we officially support the following platforms:
   - FreeBSD
   - Mac OS X (PowerPC or Intel i686 / x86_64, 10.4+)
   - Windows (i686 / x86_64)
-  - Atari TOS (68030+ CPU, TT, Falcon, accelerated ST/STE machines supported)
+  - Atari TOS (68030+ CPU, TT and Falcon machines supported)
 
 
 Requirements

--- a/README.txt
+++ b/README.txt
@@ -34,7 +34,7 @@ Currently we officially support the following platforms:
   - FreeBSD
   - Mac OS X (PowerPC or Intel i686 / x86_64, 10.4+)
   - Windows (i686 / x86_64)
-  - Atari TOS (68030+ CPU, TT and Falcon machines supported)
+  - Atari TOS (68030+ CPU, TT, Falcon and accelerated ST/STE supported)
 
 
 Requirements

--- a/src/audio/dsp_atari.c
+++ b/src/audio/dsp_atari.c
@@ -2,6 +2,7 @@
 
 #include <mint/osbind.h>
 #include <mint/ostruct.h>
+#include <mint/cookie.h>
 
 #include "types.h"
 #include "../os/endian.h"
@@ -40,6 +41,17 @@ void DSP_Uninit(void)
 
 bool DSP_Init(void) 
 {
+	/* Get sound hardware with '_SND' cookie */
+	long snd_cookie;
+	if (Getcookie(C__SND, &snd_cookie) != C_FOUND)
+		snd_cookie = 0;
+
+	/* Check for DMA support */
+	if (!(snd_cookie & 2)) {
+		Warning("No Sound DMA detected\n");
+		return false;
+	}
+
 	/* allocate ST RAM buffer for audio */
 	s_stRamBufferSize = DMASOUND_BUFFER_SIZE;
 	s_stRamBuffer = (uint8 *)Mxalloc(s_stRamBufferSize, MX_STRAM);

--- a/src/video/c2p1x1_8.s
+++ b/src/video/c2p1x1_8.s
@@ -2,11 +2,14 @@
 	xdef	_c2p1x1_8_falcon	;export symbol
 	xdef	_c2p1x1_8_tt		;export symbol
 	xdef	_c2p1x1_8_tt_partial		;export symbol
+	xdef	_c2p1x1_4_st		;export symbol	
 	;code
+
 
 ; prototypes :
 ; void c2p1x1_8_falcon(const void * chunky, void * planar, long screen_size);
 ; void c2p1x1_8_tt(const void * chunky, void * planar, long screen_size);
+; void c2p1x1_4_st(const void * chunky, void * planar, long screen_size, void * pal);
 ;
 ; c2p1x1_8_tt function double each 320 pixel line in the planar buffer,
 ; so a 320x200(320x240) screen is converted to 320x400(320x480) to
@@ -621,6 +624,133 @@ _c2p1x1_8_tt_partial:
 	move.l	a5,(a1)+
 	move.l	a6,320(a1)
 	move.l	a6,(a1)+
+
+	movem.l	(sp)+,d2-d7/a2-a6
+	rts
+
+
+
+_c2p1x1_4_st:
+	movem.l	d2-d7/a2-a6,-(sp)
+	move.l	60(sp),a3							; a3 = color remapping table
+	move.l	56(sp),d0
+	move.l	52(sp),a0							; a0 = src
+	move.l	48(sp),a1							; a1 = dst
+	move.l	a0,a2
+	add.l	d0,a2								; a2 = end
+
+	move.l	#$00ff00ff,d5						; mask
+	move.l	#$55555555,d6						; mask
+	moveq.l	#0,d4								; color reduction lookup
+
+.start:
+    ; read pixels 0-3 and reduce to 16 colors
+    move.b  (a0)+,d4
+    move.b  (a3,d4.w),d0
+    lsl.l   #8,d0
+    move.b  (a0)+,d4
+    or.b    (a3,d4.w),d0
+    lsl.l   #8,d0
+    move.b  (a0)+,d4
+    or.b    (a3,d4.w),d0
+    lsl.l   #8,d0
+    move.b  (a0)+,d4                        
+    or.b    (a3,d4.w),d0
+	; read pixels 4-7 and reduce to 16 colors
+    move.b  (a0)+,d4
+    move.b  (a3,d4.w),d2
+    lsl.l   #8,d2
+    move.b  (a0)+,d4
+    or.b    (a3,d4.w),d2
+    lsl.l   #8,d2
+    move.b  (a0)+,d4
+    or.b    (a3,d4.w),d2
+    lsl.l   #8,d2
+    move.b  (a0)+,d4
+    or.b    (a3,d4.w),d2
+    ; read pixels 8-11 and reduce to 16 colors
+    move.b  (a0)+,d4
+    move.b  (a3,d4.w),d1
+    lsl.l   #8,d1
+    move.b  (a0)+,d4
+    or.b    (a3,d4.w),d1
+    lsl.l   #8,d1
+    move.b  (a0)+,d4
+    or.b    (a3,d4.w),d1
+    lsl.l   #8,d1
+    move.b  (a0)+,d4
+    or.b    (a3,d4.w),d1
+    ; read pixels 12-15 and reduce to 16 colors
+    move.b  (a0)+,d4
+    move.b  (a3,d4.w),d3
+    lsl.l   #8,d3
+    move.b  (a0)+,d4
+    or.b    (a3,d4.w),d3
+    lsl.l   #8,d3
+    move.b  (a0)+,d4
+    or.b    (a3,d4.w),d3
+    lsl.l   #8,d3
+    move.b  (a0)+,d4
+    or.b    (a3,d4.w),d3
+
+	lsl.l	#4,d0								; shift into high nibble
+	lsl.l	#4,d1								; shift into high nibble
+	or.l	d2,d0								; combine nibbles of pixels 0-7
+	or.l	d3,d1								; combine nibbles of pixles 8-15
+
+	; a3a2a1a0e3e2e1e0 b3b2b1b0f3f2f1f0 c3c2c1c0g3g2g1g0 d3d2d1d0h3h2h1h0
+	; i3i2i1i0m3m2m1m0 j3j2j1j0n3n2n1n0 k3k2k1k0o3o2o1o0 l3l2l1l0p3p2p1p0
+
+	move.l	d1,d7								; pixels 8-15
+	lsr.l	#8,d7								; pixels 8-13
+	eor.l	d0,d7
+	and.l	d5,d7
+	eor.l	d7,d0
+	lsl.l	#8,d7
+	eor.l	d7,d1
+
+	; a3a2a1a0e3e2e1e0 i3i2i1i0m3m2m1m0 c3c2c1c0g3g2g1g0 k3k2k1k0o3o2o1o0
+	; b3b2b1b0f3f2f1f0 j3j2j1j0n3n2n1n0 d3d2d1d0h3h2h1h0 l3l2l1l0p3p2p1p0
+
+	move.l	d1,d7
+	lsr.l	#1,d7
+	eor.l	d0,d7
+	and.l	d6,d7
+	eor.l	d7,d0
+	add.l	d7,d7
+	eor.l	d7,d1
+
+	; a3b3a1b1e3f3e1f1 i3j3i1j1m3n3m1n1 c3d3c1d1g3h3g1h1 k3l3k1l1o3p3o1p1
+	; a2b2a0b0e2f2e0f0 i2j2i0j0m2n2m0n0 c2d2c0d0g2h2g0h0 k2l2k0l0o2p2o0p0
+
+	move.w	d1,d7
+	move.w	d0,d1
+	swap	d1
+	move.w	d1,d0
+	move.w	d7,d1
+
+	; a3b3a1b1e3f3e1f1 i3j3i1j1m3n3m1n1 a2b2a0b0e2f2e0f0 i2j2i0j0m2n2m0n0
+	; c3d3c1d1g3h3g1h1 k3l3k1l1o3p3o1p1 c2d2c0d0g2h2g0h0 k2l2k0l0o2p2o0p0
+
+	move.l	d1,d7
+	lsr.l	#2,d7
+	eor.l	d0,d7
+	and.l	#$33333333,d7
+	eor.l	d7,d0
+	lsl.l	#2,d7
+	eor.l	d7,d1
+
+	; a3b3c3d3e3f3g3h3 i3j3k3l3m3n3o3p3 a2b2c2d2e2f2g2h2 i2j2k2l2m2n2o2p2
+	; a1b1c1d1e1f1g1h1 i1j1k1l1m1n1o1p1 a0b0c0d0e0f0g0h0 i0j0k0l0m0n0o0p0
+
+	swap	d0
+	swap	d1
+
+	move.l	d1,(a1)+							; store planes 0-1
+	move.l	d0,(a1)+							; store planes 2-3
+
+	cmp.l	a0,a2
+	bne.w	.start
 
 	movem.l	(sp)+,d2-d7/a2-a6
 	rts

--- a/src/video/video_atari.c
+++ b/src/video/video_atari.c
@@ -318,9 +318,6 @@ static void Video_Atari_DrawChar(uint8 * screen, uint16 x, uint8 digit)
 	}
 }
 
-
-static uint8 _temp_buf[320*200];
-
 /**
  * Runs every tick to handle video updates.
  */

--- a/src/video/video_atari.c
+++ b/src/video/video_atari.c
@@ -26,6 +26,7 @@ extern void uninstall_ikbd_handler(void);
 extern void c2p1x1_8_falcon(void * planar, void * chunky, uint32 count);
 extern void c2p1x1_8_tt(void * planar, void * chunky, uint32 count);
 extern void c2p1x1_8_tt_partial(void * planar, void * chunky, uint32 count);
+extern void c2p1x1_4_st(void * planar, void * chunky, uint32 count, void * pal);
 
 /* switch FPS display */
 extern void Video_SwitchFPSDisplay(uint8 key);
@@ -39,17 +40,68 @@ static uint8 * s_framebuffer = NULL;
 static uint32 s_center_image_offset = 0;
 
 static short s_savedMode = 0;
+static void* s_savedLogBase = 0;
+static void* s_savedPhysBase = 0;
 
 static enum {
 	MCH_UNKNOWN=0, MCH_ST, MCH_STE, MCH_TT, MCH_FALCON, MCH_OTHER
 } s_machine_type = MCH_UNKNOWN;
 
 static uint32 s_paletteBackup[256];
+static uint16 s_SquareTable[256];
 
 static uint16 s_screenOffset = 0;
 static bool s_screen_needrepaint = false;
 
 static bool s_showFPS = false;
+
+/* 4bit palette */
+#define MAKE_PC_COLOR(_r,_g,_b) _r>>2,_g>>2,_b>>2,0
+const uint8 s_palette4BitPC[16*4] =	
+{
+	MAKE_PC_COLOR(20,12,28), MAKE_PC_COLOR(68,36,52), MAKE_PC_COLOR(48,52,109),	MAKE_PC_COLOR(78,74,78),
+	MAKE_PC_COLOR(133,76,48), MAKE_PC_COLOR(52,101,36), MAKE_PC_COLOR(208,70,72), MAKE_PC_COLOR(117,113,97),
+	MAKE_PC_COLOR(89,125,206), MAKE_PC_COLOR(210,125,44), MAKE_PC_COLOR(133,149,161), MAKE_PC_COLOR(109,170,44),
+	MAKE_PC_COLOR(210,170,153), MAKE_PC_COLOR(109,194,202), MAKE_PC_COLOR(218,212,94), MAKE_PC_COLOR(222,238,214)
+};
+
+static uint8 s_palette4BitMap[256];
+
+static inline uint8 Palette_FindClosestColor(uint8 r, uint8 g, uint8 b)
+{
+	uint8 i;
+	uint32 ar, ag, ab, sum;
+	uint8 bestItem = 0;
+	uint32 bestSum = (uint32) - 1;
+	const uint8 *pal = s_palette4BitPC;
+
+	r &= ~3; g &= ~3; b &= ~3;
+	for (i=0; i<16; i++, pal+=4)
+	{
+		ar = pal[0] & ~3;
+		ag = pal[1] & ~3;
+		ab = pal[2] & ~3;
+		if (ar==r && ag==g && ab==b)
+			return i;
+
+		ar = (ar > r) ? ar - r : r - ar;
+		ag = (ag > g) ? ag - g : g - ag;
+		ab = (ab > b) ? ab - b : b - ab;
+
+		ar = s_SquareTable[ar];
+		ag = s_SquareTable[ag];
+		ab = s_SquareTable[ab];
+		sum = ((ar<<1)+ar) + ((ag<<2)+(ag<<1)) + (ab<<1);	/* (r*3 + g*6 + b*2) */
+
+		if (sum < bestSum)
+		{
+			bestSum = sum;
+			bestItem = i;
+		}
+	}
+	return bestItem;
+}
+
 
 /* mouse : */
 static int s_mouse_x = SCREEN_WIDTH/2;
@@ -134,6 +186,7 @@ bool Video_Init(int screen_magnification, VideoScaleFilter filter)
 {
 	VARIABLE_NOT_USED(filter);
 	VARIABLE_NOT_USED(screen_magnification);
+	int i;
 
 	s_framebuffer = calloc(1, SCREEN_WIDTH * (SCREEN_HEIGHT + 4));
 	if (s_framebuffer == NULL) {
@@ -143,10 +196,7 @@ bool Video_Init(int screen_magnification, VideoScaleFilter filter)
 
 	(void)Cconws("Video_Init()\r\n");
 	if(s_machine_type == MCH_UNKNOWN) Detect_Machine();
-	if(s_machine_type == MCH_ST || s_machine_type == MCH_STE) {
-		Error("Only TT and Falcon 8bpp graphics supported.\n");
-		return false;
-	}
+
 	(void)Cursconf(0, 0);	/* switch cursor Off */
 	g_consoleActive = false;
 
@@ -172,10 +222,30 @@ bool Video_Init(int screen_magnification, VideoScaleFilter filter)
 		EsetShift(TT_LOW); /* set TT 8bps video mode */
 		EgetPalette(0, 256, s_paletteBackup);	/* backup palette */
 		s_center_image_offset = 320*40;
+	} else if (s_machine_type == MCH_ST || s_machine_type == MCH_STE) {
+		/* set ST/STE 4bps video mode */
+		uint32 saddr;
+		long size = (SCREEN_WIDTH*(4+SCREEN_HEIGHT)/2) + 256;
+		saddr = (uint32) Mxalloc(size, 0);	/* allocate from ST-RAM */
+		if (saddr & 0x80000000)
+			saddr = (uint32)malloc(size);	/* use malloc() if Mxalloc is not available (TOS <= 1.04) */
+		saddr = (saddr + 255) & 0x00FFFF00;	/* 256byte alignment */
+		s_savedMode = Getrez();
+		s_savedLogBase = Logbase();
+		s_savedPhysBase = Physbase();
+		Setscreen(saddr,saddr,0);	 /* set ST-Low resolution */
+		/* set and backup system palette */
+		for (i=0; i<16; i++) {
+			s_paletteBackup[i] = Setcolor(i, ((s_palette4BitPC[i*4+0] << 5) & 0x0700) | ((s_palette4BitPC[i*4+1] << 1) & 0x0070) | ((s_palette4BitPC[i*4+2]>>3) & 0x007));
+		}
 	} else {
 		Error("Unsupported machine type.\nPlease contact us if you know how to initialize a 256 color mode on your machine.\n");
 		return false;
 	}
+	
+	/* build square table */
+	for (i=0; i<256; i++)
+		s_SquareTable[i] = (uint16)(i * i);
 
 	Debug("old video mode = $%04hx\n", s_savedMode);
 	Debug("Physbase() = $%08x  Logbase() = $%08x\n", Physbase(), Logbase());
@@ -202,6 +272,13 @@ void Video_Uninit(void)
 	} else if(s_machine_type == MCH_TT) {
 		EsetPalette(0, 256, s_paletteBackup);
 		(void)EsetShift(s_savedMode);
+	} else if (s_machine_type == MCH_ST || s_machine_type == MCH_STE) {
+		int i;
+		for (i=0; i<16; i++) {
+			int oldColor = Setcolor(i, s_paletteBackup[i]);
+			VARIABLE_NOT_USED(oldColor);
+		}
+		Setscreen(s_savedLogBase, s_savedPhysBase, s_savedMode);
 	}
 	Supexec(uninstall_ikbd_handler);
 	g_consoleActive = true;
@@ -241,6 +318,9 @@ static void Video_Atari_DrawChar(uint8 * screen, uint16 x, uint8 digit)
 	}
 }
 
+
+static uint8 _temp_buf[320*200];
+
 /**
  * Runs every tick to handle video updates.
  */
@@ -275,8 +355,14 @@ void Video_Tick(void)
 				return;
 			}
 			data += area->top * SCREEN_WIDTH;
-			screen += area->top * SCREEN_WIDTH;
-			if(s_machine_type == MCH_TT) screen += area->top * SCREEN_WIDTH;
+			if (s_machine_type == MCH_TT) {
+				screen += area->top * (SCREEN_WIDTH << 1);
+			} else if (s_machine_type == MCH_ST || s_machine_type == MCH_STE) {
+				screen += area->top * (SCREEN_WIDTH >> 1);
+			} else {
+				screen += area->top * SCREEN_WIDTH;
+			}
+			
 			if (area->bottom > SCREEN_HEIGHT) {
 				Warning("GFX_Screen_GetDirtyArea: (%hu, %hu) - (%hu, %hu)\n", area->left, area->top, area->right, area->bottom);
 				area->bottom = SCREEN_HEIGHT;
@@ -319,7 +405,7 @@ void Video_Tick(void)
 				}
 #endif
 			}
-		} else {
+		} else if (s_machine_type == MCH_FALCON) {
 			if (width == SCREEN_WIDTH) {
 				c2p1x1_8_falcon(screen, data, height*SCREEN_WIDTH);
 			} else {
@@ -345,7 +431,36 @@ void Video_Tick(void)
 				}
 #endif
 			}
+		} else if (s_machine_type == MCH_ST ||s_machine_type == MCH_STE) { 
+			int i;
+			data += (s_screenOffset << 2);
+			if (width == SCREEN_WIDTH) {
+				c2p1x1_4_st(screen, data, height*SCREEN_WIDTH, s_palette4BitMap);
+			} else {
+#ifdef GFX_STORE_DIRTY_AREA_BLOCKS
+				int y;
+				for (y = area->top; y < area->bottom; y++) {
+					if (g_dirty_blocks[y] != 0) {
+						left = __builtin_ctz(g_dirty_blocks[y]) << 4;
+						width = ((32 - __builtin_clz(g_dirty_blocks[y])) << 4) - left;
+						c2p1x1_4_st(screen + (left >> 1), data + left, width, s_palette4BitMap);
+					}
+					screen += SCREEN_WIDTH >> 1;
+					data += SCREEN_WIDTH;
+				}
+#else
+				screen += (left >> 1);
+				data += left;
+				while(height > 0) {
+					c2p1x1_4_st(screen, data, width, s_palette4BitMap);
+					screen += SCREEN_WIDTH >> 1;
+					data += SCREEN_WIDTH;
+					height--;
+				}
+#endif
+			}
 		}
+		
 		GFX_Screen_SetClean(SCREEN_0);
 		s_screen_needrepaint = false;
 	}
@@ -409,6 +524,18 @@ void Video_SetPalette(void *palette, int from, int length)
 			p += 3;
 		}
 		EsetPalette(from, length, rgb12);
+	} else if (s_machine_type == MCH_ST || s_machine_type == MCH_STE) {
+		uint8 red,green,blue;
+		for (i = from; i < from + length; i++)
+		{
+			red = *p++;
+			green = *p++;
+			blue = *p++;
+			s_palette4BitMap[i] = Palette_FindClosestColor(red, green, blue);
+		}
+		/* repaint only when a large amount of colors are changing, for fading and so on */
+		if (length >= 128)
+			s_screen_needrepaint = true;
 	} else {
 		Error("don't know how to set palette on this machine.\n");
 	}


### PR DESCRIPTION
Made to run on accelerated Atari ST/STE with the following changes:
- Disables DMA sound when no such hardware exist.
- Runs in 16 color ST-Low resolution on ST/STE machines.

I'd consider it a bit experimental.

Large color changes triggers a full redraw to accommodate fading, and just generally setting up colors between various parts of the game.
Small-scale color cycling is not supported.
