### PR TITLE
timer: avoid Linux misfeature

### DIFF
--- a/src/timer.c
+++ b/src/timer.c
@@ -206,7 +206,11 @@ static void Timer_InterruptSuspend(void)
 	if (s_timerThread != NULL) DeleteTimerQueueTimer(NULL, s_timerThread, NULL);
 	s_timerThread = NULL;
 #else
-	setitimer(ITIMER_REAL, NULL, NULL);
+	s_timerTime.it_value.tv_sec = 0;
+	s_timerTime.it_value.tv_usec = 0;
+	s_timerTime.it_interval.tv_sec = 0;
+	s_timerTime.it_interval.tv_usec = 0;
+	setitimer(ITIMER_REAL, &s_timerTime, NULL);
 #endif /* _WIN32 */
 }
 


### PR DESCRIPTION
The behaviour of `setitimer(timer, NULL, &old_value)` is unspecified. FreeBSD and other systems redirect it as `getitimer(timer, &old_value)`, with a null pointer dereference in this specific case, as `&old_value` is also NULL. Other systems return an error. Linux seems to be the only one to treat that as intended here: as if called with a zero-filled itimerval to disable the timer, but even Linux warns about and against that use.