### PR TITLE
-mmacosx-version-min=10.7

### DIFF
--- a/config.lib
+++ b/config.lib
@@ -973,7 +973,7 @@ make_cflags_and_ldflags() {
 			# Universal builds set the version elsewhere.
 			if [ "$cpu_type" = "64" ]; then
 				if [ -n "$sdl2_config" ]; then
-					CFLAGS="$CFLAGS -mmacosx-version-min=10.6"
+					CFLAGS="$CFLAGS -mmacosx-version-min=10.7"
 				else
 					CFLAGS="$CFLAGS -mmacosx-version-min=10.5"
 				fi


### PR DESCRIPTION
```
[SRC] Compiling audio/dsp_sdl.c
In file included from /Users/runner/work/OpenDUNE/OpenDUNE/src/audio/dsp_sdl.c:4:
In file included from /usr/local/include/SDL2/SDL.h:32:
In file included from /usr/local/include/SDL2/SDL_main.h:25:
In file included from /usr/local/include/SDL2/SDL_stdinc.h:31:
In file included from /usr/local/include/SDL2/SDL_config.h:33:
/usr/local/include/SDL2/SDL_platform.h:112:3: error: SDL for Mac OS X only supports deploying on 10.7 and above.
 # error SDL for Mac OS X only supports deploying on 10.7 and above.
   ^
```