### PR TITLE
add midideviceid= option to opendune.ini

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -86,6 +86,7 @@ Available options are :
                 for Munt MT32 emulator.
 - fs_soundfont : SoundFont2 file for FluidSynth
 - fs_audiodriver : FluidSynth audio driver name (alsa, jack, oss, etc.)
+- midideviceid : Windows MIDI Device ID to use (default is 0)
 
 debug options (for developpers) :
 - dune2_enhanced : 0 = game acts like the original Dune II, including bugs

--- a/bin/opendune.ini.sample
+++ b/bin/opendune.ini.sample
@@ -24,6 +24,8 @@
 ; FluidSynth settings
 fs_soundfont=/usr/local/share/soundfonts/default.sf2
 fs_audiodriver=oss
+; use the following option to force the Windows MIDI Device ID
+midideviceid=0
 
 ; Game behaviour options :
 ;dune2_enhanced=0

--- a/src/audio/midi_win32.c
+++ b/src/audio/midi_win32.c
@@ -30,6 +30,8 @@ bool midi_init(void)
 				if (strstr(caps.szPname, "MT-32") != NULL) devID = i;
 			}
 		}
+	} else {
+		devID = (uint32)IniFile_GetInteger("midideviceid", 0);
 	}
 
 	/* No callback to process messages related to the progress of the playback */


### PR DESCRIPTION
to be able to select which device is selected.
default value is 0

fixes #375