### PR TITLE
OSX : try ~/Library/Application Support/OpenDUNE/data

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -67,6 +67,10 @@ Copy the original Dune2 1.07 data files (including dune2.exe) to data/.
   only with the eu data files the German language will work.
 Start 'opendune'.
 
+OS X/macOS : data files are searched additionaly in the Contents/Resources/data
+subdirectory of the application bundle, and in
+~/Library/Application Support/OpenDUNE/data
+
 Additional options may be specified using an opendune.ini file located
 in the data/ directory, in the current directory or in %APPDATA%\OpenDUNE
 (on Windows) or ~/Library/Application Support/OpenDUNE (on Mac OS X) or

--- a/src/file.c
+++ b/src/file.c
@@ -528,6 +528,7 @@ bool File_Init(void)
 	char buf[1024];
 	char *homedir = NULL;
 #ifdef OSX
+	struct stat st;
 	CFBundleRef mainBundle = CFBundleGetMainBundle();
 #endif /* OSX */
 
@@ -599,6 +600,14 @@ bool File_Init(void)
 			CFRelease(bundleURL);
 		}
 	}
+	if (stat(g_dune_data_dir, &st) < 0) {
+		/* try ~/Library/Application Support/OpenDUNE/data */
+		homedir = getenv("HOME");
+		if (homedir != NULL) {
+			snprintf(g_dune_data_dir, sizeof(g_dune_data_dir), "%s/Library/Application Support/OpenDUNE/data", homedir);
+			Debug("datadir set to : %s\n", g_dune_data_dir);
+		}
+    }
 #endif /* OSX */
 	if (IniFile_GetString("datadir", NULL, buf, sizeof(buf)) != NULL) {
 		/* datadir is defined in opendune.ini */


### PR DESCRIPTION
(when there is no /data directory in the bundle)

fixes #391 