### PR TITLE
CI: Update checkout and upload-artifact to v4

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -21,7 +21,7 @@ jobs:
           - os: macos-latest
             env: "mingw"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install dependencies Mac
         if: ${{ runner.os == 'MacOS' }}
         env:
@@ -66,7 +66,7 @@ jobs:
         run:
           make bundle_zip
       - name: Upload Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: OpenDune ${{ matrix.os }} ${{ matrix.env }}
           path: bundles/opendune-custom-*.zip


### PR DESCRIPTION
Updates checkout and upload-artifact to v4 in GitHub Actions. 

This should silence the 9 warnings. 

Further information on the deprecations can be found [here](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/) and [here](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions)

Testing: 
- Ensure that CI passes