### PR TITLE
allow HIGHDPI window

### DIFF
--- a/src/video/video_sdl2.c
+++ b/src/video/video_sdl2.c
@@ -295,7 +295,7 @@ bool Video_Init(int screen_magnification, VideoScaleFilter filter)
 #ifndef WITHOUT_SDLIMAGE
 	SDL_Surface * icon;
 #endif /* WITHOUT_SDLIMAGE */
-	uint32 window_flags = 0;
+	uint32 window_flags = SDL_WINDOW_ALLOW_HIGHDPI;
 	uint32 renderer_flags;
 
 	if (s_video_initialized) return true;


### PR DESCRIPTION
for Retina screens, for example on Mac or mobile devices.

Reference: https://wiki.libsdl.org/SDL2/SDL_WindowFlags

Have a nice week
midzer