### PR TITLE
fix: guard bool typedef for GCC 15 / C23 compatibility

### DIFF
--- a/include/types.h
+++ b/include/types.h
@@ -109,10 +109,16 @@ typedef struct tile32 {
 #undef pixel
 #endif
 
+#if !defined(__STDC_VERSION__) || __STDC_VERSION__ < 202311L
 #ifndef bool
 typedef unsigned char bool;
+#endif
+#ifndef false
 #define false 0
+#endif
+#ifndef true
 #define true 1
-#endif /* bool */
+#endif
+#endif /* !C23 */
 
 #endif /* TYPES_H */


### PR DESCRIPTION
Fixes #414

## Problem
In C23, `bool` is a keyword (incorporated from `<stdbool.h>` into the language proper). The file `include/types.h` has:

```c
#ifndef bool
typedef unsigned char bool;
...
```

This `#ifndef bool` guard doesn't help — `bool` is a keyword, not a preprocessor macro, so `#ifndef bool` always evaluates to true and the typedef always executes, causing a compilation error under GCC 15 (which defaults to C23).

## Fix
Wrap the `bool` typedef and `true`/`false` defines in a preprocessor check for the C standard version:

```c
#if !defined(__STDC_VERSION__) || __STDC_VERSION__ < 202311L
#ifndef bool
typedef unsigned char bool;
#endif
#ifndef false
#define false 0
#endif
#ifndef true
#define true 1
#endif
#endif /* !C23 */
```

In C23 or later, all three (`bool`, `true`, `false`) are provided by the language — no definitions needed. For older standards, the existing behavior is preserved. The `!defined(__STDC_VERSION__)` handles pre-C11 compilers that don't define the macro.

## Testing
Verified the build passes with `./configure && make -j$(nproc)` on Linux.