### PR TITLE
Refactor GUI and Mentat code for safety and clarity

### DIFF
--- a/src/gui/gui.c
+++ b/src/gui/gui.c
@@ -3237,7 +3237,7 @@ static void GUI_StrategicMap_ReadHouseRegions(uint8 houseID, uint16 campaignID)
 
 static void GUI_StrategicMap_DrawRegion(uint8 houseId, uint16 region, bool progressive)
 {
-	char key[4];
+	char key[6];
 	char buffer[81];
 	int16 x;
 	int16 y;
@@ -3245,7 +3245,7 @@ static void GUI_StrategicMap_DrawRegion(uint8 houseId, uint16 region, bool progr
 
 	GUI_Palette_CreateRemap(houseId);
 
-	sprintf(key, "%hu", region);
+	snprintf(key, sizeof(key), "%hu", region);
 
 	Ini_GetString("PIECES", key, NULL, buffer, sizeof(buffer), g_fileRegionINI);
 	sscanf(buffer, "%hd,%hd", &x, &y);
@@ -3280,7 +3280,7 @@ static void GUI_StrategicMap_PrepareRegions(uint16 campaignID)
 static void GUI_StrategicMap_ShowProgression(uint16 campaignID)
 {
 	char key[10];
-	char category[10];
+	char category[12];
 	char buf[100];
 	uint16 i;
 

--- a/src/gui/mentat.c
+++ b/src/gui/mentat.c
@@ -210,7 +210,8 @@ static void GUI_Mentat_LoadHelpSubjects(bool init)
 		s_selectedHelpSubject = 0;
 
 		sprintf(s_mentatFilename, "MENTAT%c", g_table_houseInfo[g_playerHouseID].name[0]);
-		strncpy(s_mentatFilename, String_GenerateFilename(s_mentatFilename), sizeof(s_mentatFilename));
+		strncpy(s_mentatFilename, String_GenerateFilename(s_mentatFilename), sizeof(s_mentatFilename) - 1);
+		s_mentatFilename[sizeof(s_mentatFilename) - 1] = '\0';
 	}
 
 	fileID = ChunkFile_Open(s_mentatFilename);

--- a/src/os/strings.h
+++ b/src/os/strings.h
@@ -82,8 +82,9 @@
 	#endif
 	#endif /* __MINGW32__ && __STRICT_ANSI__ */
 
-	#if !defined(__MINGW32__) && defined(__GNUC__) && !defined(snprintf) && !defined(__OS2__)
-		/* (v)snprintf is in fact C99, but we like to use it over (v)sprintf for the obvious reasons */
+	#if !defined(__MINGW32__) && defined(__GNUC__) && defined(__STRICT_ANSI__) && !defined(snprintf) && !defined(__OS2__)
+		/* (v)snprintf is in fact C99, but we like to use it over (v)sprintf for the obvious reasons.
+		 * In strict-ANSI mode glibc's <stdio.h> hides these prototypes, so declare them ourselves. */
 		#if !defined(__APPLE__) && !defined(TOS) && !defined(__FreeBSD__) && !defined(__OpenBSD__) && !defined(__DJGPP__) && !defined(__HAIKU__)
 			extern int snprintf (char *__restrict __s, size_t __maxlen, __const char *__restrict __format, ...) __THROW __attribute__ ((__format__ (__printf__, 3, 4)));
 			extern int vsnprintf (char *__restrict __s, size_t __maxlen, __const char *__restrict __format, va_list __arg) __THROW __attribute__ ((__format__ (__printf__, 3, 0)));

--- a/src/video/scale2x.h
+++ b/src/video/scale2x.h
@@ -65,6 +65,9 @@ typedef uint32_t scale2x_uint32;
 /**
  * Align a pointer.
  */
+#if defined(__GNUC__)
+__attribute__((unused))
+#endif
 static void* scale2x_align_ptr(const void* ptr)
 {
 #if SCALE2X_ALIGN_SIZE != 1


### PR DESCRIPTION
- Increased buffer sizes in GUI_StrategicMap_DrawRegion and GUI_StrategicMap_ShowProgression functions to prevent potential overflows.
- Replaced sprintf with snprintf in GUI_StrategicMap_DrawRegion for safer string formatting.
- Updated strncpy usage in GUI_Mentat_LoadHelpSubjects to ensure null-termination of the filename string.
- Added a GCC-specific attribute to scale2x_align_ptr function for unused attributes.